### PR TITLE
Validate stream index before launching ffplay

### DIFF
--- a/auto.sh
+++ b/auto.sh
@@ -155,7 +155,11 @@ handle_option() {
     2)
       echo -n "Numéro du flux (1-${#FILES[@]}) ▶ "
       read idx
-      [[ "$idx" =~ ^[0-9]+$ ]] && ffplay "rtsp://127.0.0.1:$RTSP_PORT/stream${idx}"
+      if [[ "$idx" =~ ^[0-9]+$ ]] && [ "$idx" -ge 1 ] && [ "$idx" -le "${#FILES[@]}" ]; then
+        ffplay "rtsp://127.0.0.1:$RTSP_PORT/stream${idx}"
+      else
+        echo "❌ Index invalide. Choisis un nombre entre 1 et ${#FILES[@]}."
+      fi
       ;;
     3)
       echo "🔁 Redémarrage portail HTML..."


### PR DESCRIPTION
## Summary
- check that selected stream index is within bounds before calling ffplay
- display an error message when the index is invalid

## Testing
- `bash -n auto.sh`
- `bash -c 'RTSP_PORT=8554; FILES=("video1"); IP=127.0.0.1; source <(sed -n "/^handle_option()/,/^}/p" auto.sh); printf "5\n" | handle_option 2'`


------
https://chatgpt.com/codex/tasks/task_e_689266b3907c8320bbd09a748db8b9ef